### PR TITLE
Add support for billable property

### DIFF
--- a/project.go
+++ b/project.go
@@ -246,7 +246,7 @@ func projectItems(project toggl.Project, arg string) (items []alfred.Item, err e
 		}
 	}
 
-	if alfred.FuzzyMatches("billable:", arg) {
+	if isWorkspacePremium(project.Wid) && alfred.FuzzyMatches("billable:", arg) {
 		var item alfred.Item
 
 		updateEntry := project

--- a/project.go
+++ b/project.go
@@ -246,6 +246,25 @@ func projectItems(project toggl.Project, arg string) (items []alfred.Item, err e
 		}
 	}
 
+	if alfred.FuzzyMatches("billable:", arg) {
+		var item alfred.Item
+
+		updateEntry := project
+		updateEntry.Billable = !project.Billable
+
+		item.Title = "Billable"
+		item.Subtitle = "Update default project's billable flag"
+		item.Autocomplete = "Billable: " + alfred.Stringify(project.Billable)
+		item.Arg = &alfred.ItemArg{
+			Keyword: "projects",
+			Mode:    alfred.ModeDo,
+			Data:    alfred.Stringify(projectCfg{ToUpdate: &updateEntry}),
+		}
+		item.AddCheckBox(project.Billable)
+
+		items = append(items, item)
+	}
+
 	if alfred.FuzzyMatches("timers", arg) {
 		items = append(items, alfred.Item{
 			Title:        "Time entries...",

--- a/support.go
+++ b/support.go
@@ -115,6 +115,15 @@ func getClientByID(id int) (client toggl.Client, index int, found bool) {
 	return
 }
 
+func getWorkspaceByID(id int) (workspace toggl.Workspace, index int, found bool) {
+	for i, workspace := range cache.Account.Data.Workspaces {
+		if workspace.ID == id {
+			return workspace, i, true
+		}
+	}
+	return
+}
+
 func findTimersByProjectID(pid int) (entries []toggl.TimeEntry) {
 	for _, entry := range cache.Account.Data.TimeEntries[:] {
 		if entry.Pid == pid {
@@ -187,6 +196,11 @@ func getLatestTimeEntriesForProject(pid int) (matchedArr []toggl.TimeEntry) {
 
 	sort.Sort(sort.Reverse(byTime(matchedArr)))
 	return
+}
+
+func isWorkspacePremium(id int) bool {
+	workspace, _, _ := getWorkspaceByID(id)
+	return workspace.Premium
 }
 
 func projectHasTimeEntries(pid int) bool {

--- a/time_entry.go
+++ b/time_entry.go
@@ -663,7 +663,7 @@ func timeEntryItems(entry *toggl.TimeEntry, query string) (items []alfred.Item, 
 		}
 	}
 
-	if alfred.FuzzyMatches("billable:", parts[0]) {
+	if isWorkspacePremium(entry.Wid) && alfred.FuzzyMatches("billable:", parts[0]) {
 		var item alfred.Item
 
 		updateEntry := entry.Copy()


### PR DESCRIPTION
- Add the correct call to `StartTimeEntryForProject` passing the billable property. This way new time entries will use the default value for the project.
- Adds the option to toggle the `Billable` property in the time entry options

![image](https://cloud.githubusercontent.com/assets/228037/25777582/15b75ce8-32af-11e7-8fe6-9626a81724ba.png)

This depends on 
https://github.com/jason0x43/go-toggl/pull/5
https://github.com/jason0x43/go-toggl/pull/6
